### PR TITLE
Jitter Rays to Reduce Aliasing

### DIFF
--- a/viewer/globals.js
+++ b/viewer/globals.js
@@ -77,6 +77,7 @@ varying vec3 vOrigin;
 varying vec3 vDirection;
 uniform mat4 world_T_cam;
 uniform mat4 cam_T_clip;
+varying vec2 vUv;
 
 void main() {
   vec4 posClip = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
@@ -91,6 +92,7 @@ void main() {
   vec4 nearPointWorld = world_T_cam * nearPointCam;
   vOrigin = originWorld.xyz / originWorld.w;
   vDirection = nearPointWorld.xyz / nearPointWorld.w - vOrigin;
+  vUv = posClip.xy + 0.5;
 }
 `;
 
@@ -104,6 +106,7 @@ precision highp float;
 
 varying vec3 vOrigin;
 varying vec3 vDirection;
+varying vec2 vUv;
 
 uniform int displayMode;
 


### PR DESCRIPTION
Before:
![NonJitteredNotebook](https://github.com/smerf-3d/smerf-3d.github.io/assets/174475/bb9c960f-8b0b-47d3-a122-aafa711b0706)

After:
![JitteredNotebook](https://github.com/smerf-3d/smerf-3d.github.io/assets/174475/ebdd2fb5-4d20-453b-841e-b5fee32698ba)

- Consider the optimal amount and direction to jitter, to avoid introducing artifacts onto previously smooth/clean surfaces.
- May want to jitter and average over time for TXAA-like effect.